### PR TITLE
`update-rapid-repo`: Do not pull submodules.

### DIFF
--- a/rapid_repos/templates/update-rapid-repo.sh.j2
+++ b/rapid_repos/templates/update-rapid-repo.sh.j2
@@ -28,8 +28,7 @@ cd "{{ git_root }}/$REPO"
 git fetch origin "$(jq -r .branch "$REPO_CONFIG")"
 git checkout FETCH_HEAD --force
 
-git submodule sync --recursive
-git submodule update --recursive --remote --init
+git submodule update --recursive --init
 git clean -xfdf
 git submodule foreach --recursive git clean -xfdf
 


### PR DESCRIPTION
Detailed the reasoning and thought process for the change in #1.

Closes #1