### PR TITLE
Adapt update-rapid-repo.sh for building different branches

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,3 +46,14 @@ ssh deploy@host update-rapid-repo <repo> <branch> <rapid_tag> <game_version>
 ```
 
 All arguments are optional except `<repo>`.
+
+Configuring Branch Builds
+-------------------------
+
+Every repo definition in your inventory retains a primary `branch`, which the periodic timer builds. To allow ad hoc builds for additional branches, add a `branches` list to the repo entry. The primary `branch` must also appear in that list. If the list is omitted, the role automatically limits builds to the primary branch. When triggering a build manually (for example from CI) pass the desired branch as the second argument to `update-rapid-repo`:
+
+```
+ssh deploy@host update-rapid-repo <repo> <branch>
+```
+
+Only the branches listed in the repo configuration are accepted.

--- a/README.md
+++ b/README.md
@@ -24,3 +24,25 @@ PRD_RAPID_REPO_MASTER=https://localhost:$(podman port testsrv 443 | cut -d: -f2)
 podman stop testsrv
 podman rm testsrv
 ```
+
+Deploy Key Management
+---------------------
+
+The deploy user SSH key for GitHub Actions is managed by Ansible. The key is placed in `rapid_repos/files/github-actions.pub` and installed with a command restriction:
+
+```
+command="sudo update-rapid-repo \"$SSH_ORIGINAL_COMMAND\""
+```
+
+This allows the deploy workflow to trigger builds with up to 4 arguments (repo, branch, rapid tag, game version).
+
+Example Deploy Command
+----------------------
+
+From your CI/CD workflow or manually:
+
+```
+ssh deploy@host update-rapid-repo <repo> <branch> <rapid_tag> <game_version>
+```
+
+All arguments are optional except `<repo>`.

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ Deploy Key Management
 The deploy user SSH key for GitHub Actions is managed by Ansible. The key is placed in `rapid_repos/files/github-actions.pub` and installed with a command restriction:
 
 ```
-command="sudo update-rapid-repo \"$SSH_ORIGINAL_COMMAND\""
+command="sudo update-rapid-repo $SSH_ORIGINAL_COMMAND"
 ```
 
 This allows the deploy workflow to trigger builds with up to 4 arguments (repo, branch, rapid tag, game version).
@@ -42,7 +42,7 @@ Example Deploy Command
 From your CI/CD workflow or manually:
 
 ```
-ssh deploy@host update-rapid-repo <repo> <branch> <rapid_tag> <game_version>
+ssh deploy@host <repo> <branch> <rapid_tag> <game_version>
 ```
 
 All arguments are optional except `<repo>`.
@@ -53,7 +53,7 @@ Configuring Branch Builds
 Every repo definition in your inventory retains a primary `branch`, which the periodic timer builds. To allow ad hoc builds for additional branches, add a `branches` list to the repo entry. The primary `branch` must also appear in that list. If the list is omitted, the role automatically limits builds to the primary branch. When triggering a build manually (for example from CI) pass the desired branch as the second argument to `update-rapid-repo`:
 
 ```
-ssh deploy@host update-rapid-repo <repo> <branch>
+ssh deploy@host <repo> <branch>
 ```
 
 Only the branches listed in the repo configuration are accepted.

--- a/rapid_repos/files/github-actions.pub
+++ b/rapid_repos/files/github-actions.pub
@@ -1,0 +1,2 @@
+# Public key for GitHub Actions deploy user
+ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIIYP+qJTSJY6NGBf87Bya/Pkd86/V3p/t8suZkx7yUTX github-actions

--- a/rapid_repos/meta/argument_specs.yaml
+++ b/rapid_repos/meta/argument_specs.yaml
@@ -27,4 +27,9 @@ argument_specs:
           branch:
             required: true
             type: 'str'
-            description: 'Branch name to clone'
+            description: 'Primary branch to clone and build periodically'
+          branches:
+            required: false
+            type: 'list'
+            elements: 'str'
+            description: 'Branches that are allowed to be built for this repo (defaults to the primary branch)'

--- a/rapid_repos/tasks/main.yaml
+++ b/rapid_repos/tasks/main.yaml
@@ -49,3 +49,11 @@
   community.general.archive:
     path: '{{ www_root }}/repos.txt'
     dest: '{{ www_root }}/repos.gz'
+- name: Add deploy key for GitHub Actions
+  authorized_key:
+    user: deploy
+    key: "{{ lookup('file', 'files/github-actions.pub') }}"
+    key_options: 'command="sudo update-rapid-repo \"$SSH_ORIGINAL_COMMAND\""'
+    state: present
+    manage_dir: yes
+    exclusive: no

--- a/rapid_repos/tasks/main.yaml
+++ b/rapid_repos/tasks/main.yaml
@@ -53,7 +53,7 @@
   authorized_key:
     user: deploy
     key: "{{ lookup('file', 'files/github-actions.pub') }}"
-    key_options: 'command="sudo update-rapid-repo \"$SSH_ORIGINAL_COMMAND\""'
+    key_options: 'command="sudo update-rapid-repo $SSH_ORIGINAL_COMMAND"'
     state: present
     manage_dir: yes
     exclusive: no

--- a/rapid_repos/tasks/repo.yaml
+++ b/rapid_repos/tasks/repo.yaml
@@ -3,15 +3,21 @@
   assert:
     that: repo.name is match('^[a-z0-9-]+$')
     quiet: true
+- name: Ensure default branch configured for {{ repo.name }} is allowed
+  ansible.builtin.assert:
+    that:
+    - repo.branch in (repo.branches | default([repo.branch]))
+    fail_msg: 'Default branch {{ repo.branch }} must be included in the branches list for {{ repo.name }}'
 - name: Set repo {{ repo.name }} config
   ansible.builtin.copy:
     dest: '{{ config_root }}/repo-{{ repo.name }}.json'
-    content: '{{ repo | to_json(indent=4, sort_keys=True) }}'
+    content: '{{ repo_config | to_json(indent=4, sort_keys=True) }}'
+  vars:
+    repo_config: "{{ repo | combine({'branches': repo.branches | default([repo.branch])}) }}"
 - name: Fetch {{ repo.name }} git repository
   ansible.builtin.git:
     dest: '{{ git_root }}/{{ repo.name }}'
     repo: '{{ repo.origin }}'
-    single_branch: true
     update: no
     version: "{{ repo.branch }}"
 - name: Create www repo directory

--- a/rapid_repos/templates/update-rapid-repo.sh.j2
+++ b/rapid_repos/templates/update-rapid-repo.sh.j2
@@ -3,6 +3,9 @@
 set -euo pipefail
 
 REPO="$1"
+BRANCH="${2:-}"      # Optional branch argument
+CUSTOM_RAPID_TAG="${3:-}" # Optional rapid tag argument
+CUSTOM_GAME_VERSION="${4:-}" # Optional game version argument
 
 if [[ ! "$REPO" =~ ^[a-z0-9-]{2,20}$ ]]; then
     echo "Illegal repo name"
@@ -25,14 +28,24 @@ fi
 
 cd "{{ git_root }}/$REPO"
 
-git fetch origin "$(jq -r .branch "$REPO_CONFIG")"
+# Determine branch to use
+if [[ -n "$BRANCH" ]]; then
+        BRANCH_TO_USE="$BRANCH"
+else
+        BRANCH_TO_USE="$(jq -r .branch "$REPO_CONFIG")"
+fi
+
+git fetch origin "$BRANCH_TO_USE"
 git checkout FETCH_HEAD --force
 
 git submodule update --recursive --init
 git clean -xfdf
 git submodule foreach --recursive git clean -xfdf
 
-rapid-buildgit "$PWD" / modinfo.lua \
-  "{{ www_root }}/$REPO" $(git rev-parse HEAD) $REPO
+# Determine rapid tag and game version
+TAG_TO_USE="$CUSTOM_RAPID_TAG"
+GAME_VERSION_TO_USE="$CUSTOM_GAME_VERSION"
+
+rapid-buildgit "$PWD" / modinfo.lua "{{ www_root }}/$REPO" $(git rev-parse HEAD) $REPO "$TAG_TO_USE" "$GAME_VERSION_TO_USE"
 
 ) 200>>"$REPO_CONFIG"

--- a/rapid_repos/templates/update-rapid-repo.sh.j2
+++ b/rapid_repos/templates/update-rapid-repo.sh.j2
@@ -29,10 +29,31 @@ fi
 cd "{{ git_root }}/$REPO"
 
 # Determine branch to use
+DEFAULT_BRANCH="$(jq -r '.branch // empty' "$REPO_CONFIG")"
 if [[ -n "$BRANCH" ]]; then
-        BRANCH_TO_USE="$BRANCH"
+    BRANCH_TO_USE="$BRANCH"
 else
-        BRANCH_TO_USE="$(jq -r .branch "$REPO_CONFIG")"
+    BRANCH_TO_USE="$DEFAULT_BRANCH"
+fi
+
+if [[ -z "$BRANCH_TO_USE" ]]; then
+    echo "No branch specified and no default branch configured"
+    exit 1
+fi
+
+# Validate branch is allowed for this repo
+if ! jq -e --arg branch "$BRANCH_TO_USE" '
+    ((.branches // []) + [(.branch // empty)])
+    | map(select(. != ""))
+    | index($branch) != null
+' "$REPO_CONFIG" >/dev/null; then
+    echo "Branch $BRANCH_TO_USE is not configured for repo $REPO"
+    exit 1
+fi
+
+if ! git check-ref-format --branch "$BRANCH_TO_USE" >/dev/null 2>&1; then
+    echo "Branch name $BRANCH_TO_USE is not a valid ref"
+    exit 1
 fi
 
 git fetch origin "$BRANCH_TO_USE"


### PR DESCRIPTION
Fixes #3

> Adapt [rapid-hosting/rapid_repos/tasks/repo.yaml](https://github.com/beyond-all-reason/rapid-hosting/blob/3c5b4733c521e8e5d75d8fdc95e68a1505623ef2/rapid_repos/tasks/repo.yaml#L6-L9) to be able to trigger build for multiple branches.

I'm not sure how to do that. 